### PR TITLE
#25: Add Elegant/NoClassInModule cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -28,6 +28,13 @@ Elegant/ClassInModule:
   Exclude:
     - '**/*Test.rb'
     - '**/test_*.rb'
+Elegant/NoClassInModule:
+  Description: 'Forbids declaring a class inside a module declaration; use compact namespace syntax instead'
+  Enabled: true
+  VersionAdded: '0.1.0'
+  Exclude:
+    - '**/*Test.rb'
+    - '**/test_*.rb'
 Elegant/IndentationLadder:
   Description: 'Requires the indentation step to be exactly two spaces when a line indents to the right of the previous one'
   Enabled: true

--- a/lib/rubocop-elegant.rb
+++ b/lib/rubocop-elegant.rb
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: MIT
 
 require 'rubocop'
+
+module RuboCop::Elegant; end
+
 require_relative 'rubocop/cop/elegant_cops'
 require_relative 'rubocop/elegant/plugin'
 require_relative 'rubocop/elegant/version'

--- a/lib/rubocop/cop/elegant/class_in_module.rb
+++ b/lib/rubocop/cop/elegant/class_in_module.rb
@@ -3,40 +3,34 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-module RuboCop
-  module Cop
-    module Elegant
-      # Enforces that every class be defined inside a module. A class declared
-      # at the top level, or nested only inside another class, pollutes the
-      # global namespace and breaks modular design. The compact namespaced
-      # form +class Foo::Bar+ is allowed because its name already resolves
-      # into an enclosing namespace.
-      class ClassInModule < Base
-        MSG = 'Class %<name>s must be defined inside a module, not globally'
-        public_constant :MSG
+# Enforces that every class be defined inside a module. A class declared
+# at the top level, or nested only inside another class, pollutes the
+# global namespace and breaks modular design. The compact namespaced
+# form +class Foo::Bar+ is allowed because its name already resolves
+# into an enclosing namespace.
+class RuboCop::Cop::Elegant::ClassInModule < RuboCop::Cop::Base
+  MSG = 'Class %<name>s must be defined inside a module, not globally'
+  public_constant :MSG
 
-        def on_class(node)
-          return if namespaced?(node)
-          return if scoped?(node)
-          add_offense(node, message: format(MSG, name: label(node)))
-        end
+  def on_class(node)
+    return if namespaced?(node)
+    return if scoped?(node)
+    add_offense(node, message: format(MSG, name: label(node)))
+  end
 
-        private
+  private
 
-        def namespaced?(node)
-          const = node.children[0]
-          scope = const.children[0]
-          !scope.nil? && scope.type != :cbase
-        end
+  def namespaced?(node)
+    const = node.children[0]
+    scope = const.children[0]
+    !scope.nil? && scope.type != :cbase
+  end
 
-        def scoped?(node)
-          node.each_ancestor(:module).any?
-        end
+  def scoped?(node)
+    node.each_ancestor(:module).any?
+  end
 
-        def label(node)
-          node.children[0].source
-        end
-      end
-    end
+  def label(node)
+    node.children[0].source
   end
 end

--- a/lib/rubocop/cop/elegant/good_method_name.rb
+++ b/lib/rubocop/cop/elegant/good_method_name.rb
@@ -3,41 +3,35 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-module RuboCop
-  module Cop
-    module Elegant
-      class GoodMethodName < Base
-        MSG = 'Method name "%<name>s" does not match the required pattern'
-        public_constant :MSG
+class RuboCop::Cop::Elegant::GoodMethodName < RuboCop::Cop::Base
+  MSG = 'Method name "%<name>s" does not match the required pattern'
+  public_constant :MSG
 
-        def on_def(node)
-          check(node, node.method_name.to_s)
-        end
+  def on_def(node)
+    check(node, node.method_name.to_s)
+  end
 
-        def on_defs(node)
-          check(node, node.method_name.to_s)
-        end
+  def on_defs(node)
+    check(node, node.method_name.to_s)
+  end
 
-        private
+  private
 
-        def check(node, name)
-          return if allowed?(name)
-          return if match?(name)
-          add_offense(node, message: format(MSG, name: name))
-        end
+  def check(node, name)
+    return if allowed?(name)
+    return if match?(name)
+    add_offense(node, message: format(MSG, name: name))
+  end
 
-        def match?(name)
-          pattern.match?(name)
-        end
+  def match?(name)
+    pattern.match?(name)
+  end
 
-        def allowed?(name)
-          Array(cop_config['AllowedNames']).map(&:to_s).include?(name)
-        end
+  def allowed?(name)
+    Array(cop_config['AllowedNames']).map(&:to_s).include?(name)
+  end
 
-        def pattern
-          @pattern ||= Regexp.new(cop_config['Pattern'] || '^[a-z]+[!?]?$')
-        end
-      end
-    end
+  def pattern
+    @pattern ||= Regexp.new(cop_config['Pattern'] || '^[a-z]+[!?]?$')
   end
 end

--- a/lib/rubocop/cop/elegant/good_variable_name.rb
+++ b/lib/rubocop/cop/elegant/good_variable_name.rb
@@ -3,49 +3,43 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-module RuboCop
-  module Cop
-    module Elegant
-      class GoodVariableName < Base
-        MSG = 'Variable name "%<name>s" does not match the required pattern'
-        public_constant :MSG
+class RuboCop::Cop::Elegant::GoodVariableName < RuboCop::Cop::Base
+  MSG = 'Variable name "%<name>s" does not match the required pattern'
+  public_constant :MSG
 
-        def on_lvasgn(node)
-          check(node, node.children.first.to_s)
-        end
+  def on_lvasgn(node)
+    check(node, node.children.first.to_s)
+  end
 
-        def on_ivasgn(node)
-          check(node, node.children.first.to_s)
-        end
+  def on_ivasgn(node)
+    check(node, node.children.first.to_s)
+  end
 
-        def on_cvasgn(node)
-          check(node, node.children.first.to_s)
-        end
+  def on_cvasgn(node)
+    check(node, node.children.first.to_s)
+  end
 
-        def on_gvasgn(node)
-          check(node, node.children.first.to_s)
-        end
+  def on_gvasgn(node)
+    check(node, node.children.first.to_s)
+  end
 
-        private
+  private
 
-        def check(node, name)
-          return if allowed?(name)
-          return if match?(name)
-          add_offense(node, message: format(MSG, name: name))
-        end
+  def check(node, name)
+    return if allowed?(name)
+    return if match?(name)
+    add_offense(node, message: format(MSG, name: name))
+  end
 
-        def match?(name)
-          pattern.match?(name)
-        end
+  def match?(name)
+    pattern.match?(name)
+  end
 
-        def allowed?(name)
-          Array(cop_config['AllowedNames']).map(&:to_s).include?(name)
-        end
+  def allowed?(name)
+    Array(cop_config['AllowedNames']).map(&:to_s).include?(name)
+  end
 
-        def pattern
-          @pattern ||= Regexp.new(cop_config['Pattern'] || '^[a-z]+$')
-        end
-      end
-    end
+  def pattern
+    @pattern ||= Regexp.new(cop_config['Pattern'] || '^[a-z]+$')
   end
 end

--- a/lib/rubocop/cop/elegant/indentation_ladder.rb
+++ b/lib/rubocop/cop/elegant/indentation_ladder.rb
@@ -3,54 +3,48 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-module RuboCop
-  module Cop
-    module Elegant
-      # Enforces the "indentation ladder" rule: when a line is indented further
-      # to the right than the previous non-empty line, the extra indentation
-      # must be exactly two spaces. Larger jumps (or odd ones, such as a single
-      # space or three spaces) break the visual rhythm of the code and make
-      # nesting harder to follow. Lines that match the previous indentation, or
-      # de-indent by any amount, are not affected. Lines that belong to the
-      # body of a heredoc are ignored, because their whitespace is part of the
-      # literal value rather than program structure.
-      class IndentationLadder < Base
-        MSG = 'Indentation step of %<step>d spaces is not allowed; use 2 spaces'
-        public_constant :MSG
+# Enforces the "indentation ladder" rule: when a line is indented further
+# to the right than the previous non-empty line, the extra indentation
+# must be exactly two spaces. Larger jumps (or odd ones, such as a single
+# space or three spaces) break the visual rhythm of the code and make
+# nesting harder to follow. Lines that match the previous indentation, or
+# de-indent by any amount, are not affected. Lines that belong to the
+# body of a heredoc are ignored, because their whitespace is part of the
+# literal value rather than program structure.
+class RuboCop::Cop::Elegant::IndentationLadder < RuboCop::Cop::Base
+  MSG = 'Indentation step of %<step>d spaces is not allowed; use 2 spaces'
+  public_constant :MSG
 
-        def on_new_investigation
-          super
-          skip = heredocs
-          prev = nil
-          processed_source.lines.each_with_index do |line, idx|
-            num = idx + 1
-            next if skip.include?(num)
-            next if line.strip.empty?
-            indent = line[/\A */].length
-            register(num, indent - prev) if prev && indent > prev && (indent - prev) != 2
-            prev = indent
-          end
-        end
-
-        private
-
-        def heredocs
-          result = []
-          ast = processed_source.ast
-          return result if ast.nil?
-          ast.each_node(:str, :dstr, :xstr) do |node|
-            next unless node.heredoc?
-            body = node.loc.heredoc_body
-            (body.first_line..body.last_line).each { |num| result << num }
-          end
-          result
-        end
-
-        def register(num, step)
-          target = processed_source.buffer.line_range(num)
-          add_offense(target, message: format(MSG, step: step))
-        end
-      end
+  def on_new_investigation
+    super
+    skip = heredocs
+    prev = nil
+    processed_source.lines.each_with_index do |line, idx|
+      num = idx + 1
+      next if skip.include?(num)
+      next if line.strip.empty?
+      indent = line[/\A */].length
+      register(num, indent - prev) if prev && indent > prev && (indent - prev) != 2
+      prev = indent
     end
+  end
+
+  private
+
+  def heredocs
+    result = []
+    ast = processed_source.ast
+    return result if ast.nil?
+    ast.each_node(:str, :dstr, :xstr) do |node|
+      next unless node.heredoc?
+      body = node.loc.heredoc_body
+      (body.first_line..body.last_line).each { |num| result << num }
+    end
+    result
+  end
+
+  def register(num, step)
+    target = processed_source.buffer.line_range(num)
+    add_offense(target, message: format(MSG, step: step))
   end
 end

--- a/lib/rubocop/cop/elegant/no_class_in_module.rb
+++ b/lib/rubocop/cop/elegant/no_class_in_module.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+# Forbids declaring a class inside a module declaration. Instead, the
+# class must be declared with the compact namespace syntax, like
+# +class Foo::Bar+. An empty module +module Foo; end+, a module that
+# contains only other modules, methods, or constants, and a class
+# nested inside another class are all allowed; only a class whose
+# nearest enclosing scope is a module is rejected.
+class RuboCop::Cop::Elegant::NoClassInModule < RuboCop::Cop::Base
+  MSG = 'Class %<name>s must use compact namespace syntax, not be nested inside a module'
+  public_constant :MSG
+
+  def on_class(node)
+    owner = node.each_ancestor(:module, :class).first
+    return if owner.nil? || !owner.module_type?
+    add_offense(node, message: format(MSG, name: label(node)))
+  end
+
+  private
+
+  def label(node)
+    node.children[0].source
+  end
+end

--- a/lib/rubocop/cop/elegant/no_comments.rb
+++ b/lib/rubocop/cop/elegant/no_comments.rb
@@ -3,110 +3,104 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-module RuboCop
-  module Cop
-    module Elegant
-      class NoComments < Base
-        extend AutoCorrector
+class RuboCop::Cop::Elegant::NoComments < RuboCop::Cop::Base
+  extend RuboCop::Cop::AutoCorrector
 
-        MSG = 'Comment is not allowed, unless it is SPDX, magic, rubocop directive, or docblock'
-        public_constant :MSG
+  MSG = 'Comment is not allowed, unless it is SPDX, magic, rubocop directive, or docblock'
+  public_constant :MSG
 
-        def on_new_investigation
-          processed_source.comments.each do |comment|
-            register(comment) unless allowed?(comment)
-          end
-        end
-
-        private
-
-        def allowed?(comment)
-          spdx?(comment) || magic?(comment) || rubocop?(comment) || (gemspec? && docblock?(comment))
-        end
-
-        def spdx?(comment)
-          comment.text.match?(/^#\s*SPDX-/)
-        end
-
-        def magic?(comment)
-          comment.text.match?(/^#\s*(frozen_string_literal|encoding|coding|warn_indent):/)
-        end
-
-        def rubocop?(comment)
-          comment.text.match?(/^#\s*rubocop:(disable|enable|todo)\s/)
-        end
-
-        def gemspec?
-          return @gemspec if defined?(@gemspec)
-          path = processed_source.path
-          return @gemspec = false if path.nil?
-          @gemspec = root(File.dirname(path))
-        end
-
-        def root(dir)
-          return true if Dir.glob(File.join(dir, '*.gemspec')).any?
-          parent = File.dirname(dir)
-          return false if parent == dir
-          root(parent)
-        end
-
-        def docblock?(comment)
-          line = comment.location.line
-          successor = codeline(line)
-          return false if successor.nil?
-          definition?(successor)
-        end
-
-        def codeline(start)
-          lines = processed_source.lines
-          (start...lines.size).each do |idx|
-            content = lines[idx]
-            next if content.nil?
-            stripped = content.strip
-            next if stripped.empty? || stripped.start_with?('#')
-            return idx + 1
-          end
-          nil
-        end
-
-        def definition?(line)
-          ast = processed_source.ast
-          return false if ast.nil?
-          ast.each_node(:class, :module, :def, :defs) do |node|
-            return true if node.location.line == line
-          end
-          false
-        end
-
-        def register(comment)
-          add_offense(comment) do |corrector|
-            corrector.remove(removal(comment))
-          end
-        end
-
-        def removal(comment)
-          target = comment.source_range
-          prefix = target.source_line[0, target.column]
-          return fullrange(target) if prefix.strip.empty?
-          prefixed(target, prefix)
-        end
-
-        def fullrange(target)
-          start = target.begin_pos - target.column
-          ending = target.end_pos
-          ending += 1 if newline?(ending)
-          target.with(begin_pos: start, end_pos: ending)
-        end
-
-        def prefixed(target, prefix)
-          spaces = prefix.match(/\s*$/)[0]
-          target.with(begin_pos: target.begin_pos - spaces.length, end_pos: target.end_pos)
-        end
-
-        def newline?(pos)
-          processed_source.buffer.source[pos] == "\n"
-        end
-      end
+  def on_new_investigation
+    processed_source.comments.each do |comment|
+      register(comment) unless allowed?(comment)
     end
+  end
+
+  private
+
+  def allowed?(comment)
+    spdx?(comment) || magic?(comment) || rubocop?(comment) || (gemspec? && docblock?(comment))
+  end
+
+  def spdx?(comment)
+    comment.text.match?(/^#\s*SPDX-/)
+  end
+
+  def magic?(comment)
+    comment.text.match?(/^#\s*(frozen_string_literal|encoding|coding|warn_indent):/)
+  end
+
+  def rubocop?(comment)
+    comment.text.match?(/^#\s*rubocop:(disable|enable|todo)\s/)
+  end
+
+  def gemspec?
+    return @gemspec if defined?(@gemspec)
+    path = processed_source.path
+    return @gemspec = false if path.nil?
+    @gemspec = root(File.dirname(path))
+  end
+
+  def root(dir)
+    return true if Dir.glob(File.join(dir, '*.gemspec')).any?
+    parent = File.dirname(dir)
+    return false if parent == dir
+    root(parent)
+  end
+
+  def docblock?(comment)
+    line = comment.location.line
+    successor = codeline(line)
+    return false if successor.nil?
+    definition?(successor)
+  end
+
+  def codeline(start)
+    lines = processed_source.lines
+    (start...lines.size).each do |idx|
+      content = lines[idx]
+      next if content.nil?
+      stripped = content.strip
+      next if stripped.empty? || stripped.start_with?('#')
+      return idx + 1
+    end
+    nil
+  end
+
+  def definition?(line)
+    ast = processed_source.ast
+    return false if ast.nil?
+    ast.each_node(:class, :module, :def, :defs) do |node|
+      return true if node.location.line == line
+    end
+    false
+  end
+
+  def register(comment)
+    add_offense(comment) do |corrector|
+      corrector.remove(removal(comment))
+    end
+  end
+
+  def removal(comment)
+    target = comment.source_range
+    prefix = target.source_line[0, target.column]
+    return fullrange(target) if prefix.strip.empty?
+    prefixed(target, prefix)
+  end
+
+  def fullrange(target)
+    start = target.begin_pos - target.column
+    ending = target.end_pos
+    ending += 1 if newline?(ending)
+    target.with(begin_pos: start, end_pos: ending)
+  end
+
+  def prefixed(target, prefix)
+    spaces = prefix.match(/\s*$/)[0]
+    target.with(begin_pos: target.begin_pos - spaces.length, end_pos: target.end_pos)
+  end
+
+  def newline?(pos)
+    processed_source.buffer.source[pos] == "\n"
   end
 end

--- a/lib/rubocop/cop/elegant/no_empty_lines_in_blocks.rb
+++ b/lib/rubocop/cop/elegant/no_empty_lines_in_blocks.rb
@@ -3,113 +3,107 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-module RuboCop
-  module Cop
-    module Elegant
-      class NoEmptyLinesInBlocks < Base
-        extend AutoCorrector
+class RuboCop::Cop::Elegant::NoEmptyLinesInBlocks < RuboCop::Cop::Base
+  extend RuboCop::Cop::AutoCorrector
 
-        MSG = 'Empty line inside block body is not allowed'
-        public_constant :MSG
+  MSG = 'Empty line inside block body is not allowed'
+  public_constant :MSG
 
-        def on_new_investigation
-          super
-          @reported = []
-          @gaps = scan
-        end
+  def on_new_investigation
+    super
+    @reported = []
+    @gaps = scan
+  end
 
-        def on_block(node)
-          check(node)
-        end
+  def on_block(node)
+    check(node)
+  end
 
-        def on_numblock(node)
-          check(node)
-        end
+  def on_numblock(node)
+    check(node)
+  end
 
-        def on_if(node)
-          check(node)
-        end
+  def on_if(node)
+    check(node)
+  end
 
-        def on_while(node)
-          check(node)
-        end
+  def on_while(node)
+    check(node)
+  end
 
-        def on_until(node)
-          check(node)
-        end
+  def on_until(node)
+    check(node)
+  end
 
-        def on_for(node)
-          check(node)
-        end
+  def on_for(node)
+    check(node)
+  end
 
-        def on_case(node)
-          check(node)
-        end
+  def on_case(node)
+    check(node)
+  end
 
-        def on_case_match(node)
-          check(node)
-        end
+  def on_case_match(node)
+    check(node)
+  end
 
-        def on_kwbegin(node)
-          check(node)
-        end
+  def on_kwbegin(node)
+    check(node)
+  end
 
-        private
+  private
 
-        def check(node)
-          lines = range(node)
-          return if lines.nil?
-          empty(lines).each { |num| register(num) }
-        end
+  def check(node)
+    lines = range(node)
+    return if lines.nil?
+    empty(lines).each { |num| register(num) }
+  end
 
-        def range(node)
-          first = node.first_line + 1
-          last = node.last_line - 1
-          return if first > last
-          (first..last)
-        end
+  def range(node)
+    first = node.first_line + 1
+    last = node.last_line - 1
+    return if first > last
+    (first..last)
+  end
 
-        def empty(lines)
-          result = []
-          lines.each do |num|
-            next if @gaps.include?(num)
-            line = processed_source.lines[num - 1]
-            result << num if line.strip.empty?
-          end
-          result
-        end
-
-        def scan
-          gaps = []
-          ast = processed_source.ast
-          return gaps if ast.nil?
-          ast.each_node(:def, :defs) do |node|
-            nxt = node.right_sibling
-            next unless nxt.is_a?(RuboCop::AST::Node)
-            next unless %i[def defs].include?(nxt.type)
-            first = node.last_line + 1
-            last = nxt.first_line - 1
-            next if first > last
-            (first..last).each { |n| gaps << n }
-          end
-          gaps
-        end
-
-        def register(num)
-          return if @reported.include?(num)
-          @reported << num
-          target = processed_source.buffer.line_range(num)
-          add_offense(target) do |corrector|
-            corrector.remove(fullrange(target))
-          end
-        end
-
-        def fullrange(target)
-          ending = target.end_pos
-          ending += 1 if processed_source.buffer.source[ending] == "\n"
-          target.with(end_pos: ending)
-        end
-      end
+  def empty(lines)
+    result = []
+    lines.each do |num|
+      next if @gaps.include?(num)
+      line = processed_source.lines[num - 1]
+      result << num if line.strip.empty?
     end
+    result
+  end
+
+  def scan
+    gaps = []
+    ast = processed_source.ast
+    return gaps if ast.nil?
+    ast.each_node(:def, :defs) do |node|
+      nxt = node.right_sibling
+      next unless nxt.is_a?(RuboCop::AST::Node)
+      next unless %i[def defs].include?(nxt.type)
+      first = node.last_line + 1
+      last = nxt.first_line - 1
+      next if first > last
+      (first..last).each { |n| gaps << n }
+    end
+    gaps
+  end
+
+  def register(num)
+    return if @reported.include?(num)
+    @reported << num
+    target = processed_source.buffer.line_range(num)
+    add_offense(target) do |corrector|
+      corrector.remove(fullrange(target))
+    end
+  end
+
+  def fullrange(target)
+    ending = target.end_pos
+    ending += 1 if processed_source.buffer.source[ending] == "\n"
+    target.with(end_pos: ending)
   end
 end

--- a/lib/rubocop/cop/elegant/no_empty_lines_in_methods.rb
+++ b/lib/rubocop/cop/elegant/no_empty_lines_in_methods.rb
@@ -3,61 +3,55 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-module RuboCop
-  module Cop
-    module Elegant
-      class NoEmptyLinesInMethods < Base
-        extend AutoCorrector
+class RuboCop::Cop::Elegant::NoEmptyLinesInMethods < RuboCop::Cop::Base
+  extend RuboCop::Cop::AutoCorrector
 
-        MSG = 'Empty line inside method body is not allowed'
-        public_constant :MSG
+  MSG = 'Empty line inside method body is not allowed'
+  public_constant :MSG
 
-        def on_def(node)
-          check(node)
-        end
+  def on_def(node)
+    check(node)
+  end
 
-        def on_defs(node)
-          check(node)
-        end
+  def on_defs(node)
+    check(node)
+  end
 
-        private
+  private
 
-        def check(node)
-          return if node.body.nil?
-          lines = range(node)
-          return if lines.nil?
-          empty(lines).each { |num| register(num) }
-        end
+  def check(node)
+    return if node.body.nil?
+    lines = range(node)
+    return if lines.nil?
+    empty(lines).each { |num| register(num) }
+  end
 
-        def range(node)
-          first = node.body.first_line
-          last = node.body.last_line
-          return if first == last
-          (first..last)
-        end
+  def range(node)
+    first = node.body.first_line
+    last = node.body.last_line
+    return if first == last
+    (first..last)
+  end
 
-        def empty(lines)
-          result = []
-          lines.each do |num|
-            line = processed_source.lines[num - 1]
-            result << num if line.strip.empty?
-          end
-          result
-        end
-
-        def register(num)
-          target = processed_source.buffer.line_range(num)
-          add_offense(target) do |corrector|
-            corrector.remove(fullrange(target))
-          end
-        end
-
-        def fullrange(target)
-          ending = target.end_pos
-          ending += 1 if processed_source.buffer.source[ending] == "\n"
-          target.with(end_pos: ending)
-        end
-      end
+  def empty(lines)
+    result = []
+    lines.each do |num|
+      line = processed_source.lines[num - 1]
+      result << num if line.strip.empty?
     end
+    result
+  end
+
+  def register(num)
+    target = processed_source.buffer.line_range(num)
+    add_offense(target) do |corrector|
+      corrector.remove(fullrange(target))
+    end
+  end
+
+  def fullrange(target)
+    ending = target.end_pos
+    ending += 1 if processed_source.buffer.source[ending] == "\n"
+    target.with(end_pos: ending)
   end
 end

--- a/lib/rubocop/cop/elegant/paired_brackets.rb
+++ b/lib/rubocop/cop/elegant/paired_brackets.rb
@@ -3,68 +3,62 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-module RuboCop
-  module Cop
-    module Elegant
-      # Enforces the "paired brackets" notation: every round, square, or curly
-      # bracket must either be paired with its matching counterpart on the same
-      # line, or end its own line (when opening) or start its own line (when
-      # closing). Brackets stranded in the middle of a multi-line expression
-      # are forbidden because they hide the structure of the code.
-      #
-      # See https://www.yegor256.com/2014/10/23/paired-brackets-notation.html
-      class PairedBrackets < Base
-        MSG = 'Bracket %<text>s must be paired on the same line, or start/end its line'
-        public_constant :MSG
+# Enforces the "paired brackets" notation: every round, square, or curly
+# bracket must either be paired with its matching counterpart on the same
+# line, or end its own line (when opening) or start its own line (when
+# closing). Brackets stranded in the middle of a multi-line expression
+# are forbidden because they hide the structure of the code.
+#
+# See https://www.yegor256.com/2014/10/23/paired-brackets-notation.html
+class RuboCop::Cop::Elegant::PairedBrackets < RuboCop::Cop::Base
+  MSG = 'Bracket %<text>s must be paired on the same line, or start/end its line'
+  public_constant :MSG
 
-        OPENERS = %i[tLPAREN tLPAREN2 tLPAREN_ARG tLBRACK tLBRACK2 tLCURLY tLBRACE tLBRACE_ARG].freeze
-        private_constant :OPENERS
+  OPENERS = %i[tLPAREN tLPAREN2 tLPAREN_ARG tLBRACK tLBRACK2 tLCURLY tLBRACE tLBRACE_ARG].freeze
+  private_constant :OPENERS
 
-        CLOSERS = %i[tRPAREN tRBRACK tRCURLY].freeze
-        private_constant :CLOSERS
+  CLOSERS = %i[tRPAREN tRBRACK tRCURLY].freeze
+  private_constant :CLOSERS
 
-        def on_new_investigation
-          super
-          pair.each { |duo| check(duo) }
-        end
+  def on_new_investigation
+    super
+    pair.each { |duo| check(duo) }
+  end
 
-        private
+  private
 
-        def pair
-          stack = []
-          result = []
-          processed_source.tokens.each do |tok|
-            if OPENERS.include?(tok.type)
-              stack << tok
-            elsif CLOSERS.include?(tok.type) && !stack.empty?
-              result << [stack.pop, tok]
-            end
-          end
-          result
-        end
-
-        def check(duo)
-          opener, closer = duo
-          return if opener.line == closer.line
-          register(opener) unless ends?(opener)
-          register(closer) unless starts?(closer)
-        end
-
-        def starts?(tok)
-          line = processed_source.lines[tok.line - 1]
-          line[0...tok.column].strip.empty?
-        end
-
-        def ends?(tok)
-          line = processed_source.lines[tok.line - 1]
-          after = line[(tok.column + tok.text.length)..-1].to_s.strip
-          after.empty? || after.start_with?('#')
-        end
-
-        def register(tok)
-          add_offense(tok.pos, message: format(MSG, text: tok.text))
-        end
+  def pair
+    stack = []
+    result = []
+    processed_source.tokens.each do |tok|
+      if OPENERS.include?(tok.type)
+        stack << tok
+      elsif CLOSERS.include?(tok.type) && !stack.empty?
+        result << [stack.pop, tok]
       end
     end
+    result
+  end
+
+  def check(duo)
+    opener, closer = duo
+    return if opener.line == closer.line
+    register(opener) unless ends?(opener)
+    register(closer) unless starts?(closer)
+  end
+
+  def starts?(tok)
+    line = processed_source.lines[tok.line - 1]
+    line[0...tok.column].strip.empty?
+  end
+
+  def ends?(tok)
+    line = processed_source.lines[tok.line - 1]
+    after = line[(tok.column + tok.text.length)..-1].to_s.strip
+    after.empty? || after.start_with?('#')
+  end
+
+  def register(tok)
+    add_offense(tok.pos, message: format(MSG, text: tok.text))
   end
 end

--- a/lib/rubocop/cop/elegant_cops.rb
+++ b/lib/rubocop/cop/elegant_cops.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
-require_relative 'elegant/class_in_module'
-require_relative 'elegant/good_method_name'
-require_relative 'elegant/good_variable_name'
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+module RuboCop::Cop::Elegant; end
+
+require_relative 'elegant/class_in_module'
+require_relative 'elegant/good_method_name'
+require_relative 'elegant/good_variable_name'
 require_relative 'elegant/indentation_ladder'
+require_relative 'elegant/no_class_in_module'
 require_relative 'elegant/no_comments'
 require_relative 'elegant/no_empty_lines_in_blocks'
 require_relative 'elegant/no_empty_lines_in_methods'

--- a/lib/rubocop/elegant/plugin.rb
+++ b/lib/rubocop/elegant/plugin.rb
@@ -5,29 +5,25 @@
 
 require 'lint_roller'
 
-module RuboCop
-  module Elegant
-    class Plugin < LintRoller::Plugin
-      def about
-        LintRoller::About.new(
-          name: 'rubocop-elegant',
-          version: VERSION,
-          homepage: 'https://github.com/yegor256/rubocop-elegant',
-          description: 'Set of custom RuboCop cops for elegant Ruby coding'
-        )
-      end
+class RuboCop::Elegant::Plugin < LintRoller::Plugin
+  def about
+    LintRoller::About.new(
+      name: 'rubocop-elegant',
+      version: RuboCop::Elegant::VERSION,
+      homepage: 'https://github.com/yegor256/rubocop-elegant',
+      description: 'Set of custom RuboCop cops for elegant Ruby coding'
+    )
+  end
 
-      def supported?(context)
-        context.engine == :rubocop
-      end
+  def supported?(context)
+    context.engine == :rubocop
+  end
 
-      def rules(_context)
-        LintRoller::Rules.new(
-          type: :path,
-          config_format: :rubocop,
-          value: Pathname.new(__dir__).join('../../../config/default.yml')
-        )
-      end
-    end
+  def rules(_context)
+    LintRoller::Rules.new(
+      type: :path,
+      config_format: :rubocop,
+      value: Pathname.new(__dir__).join('../../../config/default.yml')
+    )
   end
 end

--- a/test/elegant/test_no_class_in_module.rb
+++ b/test/elegant/test_no_class_in_module.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../lib/rubocop-elegant'
+require_relative '../test__helper'
+
+class NoClassInModuleTest < Minitest::Test
+  ALLOWED = {
+    'compact_namespaced_class' => "class Foo::Bar\nend",
+    'deeply_namespaced_compact_class' => "class Foo::Bar::Baz\nend",
+    'empty_module' => "module Foo\nend",
+    'nested_empty_modules' => "module Foo\n  module Bar\n  end\nend",
+    'module_with_method_only' => "module Foo\n  def baz\n  end\nend",
+    'module_with_constant_only' => "module Foo\n  BAR = 1\nend",
+    'module_with_method_and_constant' => "module Foo\n  BAR = 1\n  def baz\n  end\nend",
+    'plain_top_level_class' => "class Foo\nend",
+    'top_level_class_with_inheritance' => "class Foo < StandardError\nend",
+    'nested_class_inside_class_top_level' => "class Foo\n  class Bar\n  end\nend",
+    'top_level_method_only' => "def foo\nend"
+  }.freeze
+  public_constant :ALLOWED
+
+  VIOLATIONS = {
+    'class_inside_single_module' => ["module Foo\n  class Bar\n  end\nend", 1],
+    'class_inside_nested_modules' => ["module Foo\n  module Baz\n    class Bar\n    end\n  end\nend", 1],
+    'two_classes_inside_one_module' => ["module Foo\n  class Bar\n  end\n  class Baz\n  end\nend", 2],
+    'class_with_inheritance_inside_module' => ["module Foo\n  class Bar < StandardError\n  end\nend", 1],
+    'outer_class_only_when_nested_inside_class_inside_module' =>
+      ["module Foo\n  class Bar\n    class Baz\n    end\n  end\nend", 1],
+    'class_alongside_empty_submodule' => ["module Foo\n  module Bar\n  end\n  class Baz\n  end\nend", 1]
+  }.freeze
+  public_constant :VIOLATIONS
+
+  ALLOWED.each do |name, source|
+    define_method("test_allows_#{name}") do
+      total = offenses(source).size
+      assert_equal(0, total, "Expected no offense in #{name.tr('_', ' ')}, got #{total}")
+    end
+  end
+
+  VIOLATIONS.each do |name, (source, count)|
+    define_method("test_registers_offense_for_#{name}") do
+      total = offenses(source).size
+      assert_equal(count, total, "Expected #{count} offense(s) for #{name.tr('_', ' ')}, got #{total}")
+    end
+  end
+
+  private
+
+  def offenses(source)
+    config = RuboCop::Config.new
+    cop = RuboCop::Cop::Elegant::NoClassInModule.new(config)
+    commissioner = RuboCop::Cop::Commissioner.new([cop], [], raise_error: true)
+    processed = RuboCop::ProcessedSource.new(source, Float(RUBY_VERSION[/[0-9]+.[0-9]+/]))
+    result = commissioner.investigate(processed)
+    result.offenses
+  end
+end


### PR DESCRIPTION
## Summary
- Closes #25 by adding `Elegant/NoClassInModule`, which flags any `class` whose nearest enclosing scope is a `module` and pushes users toward the compact `class Foo::Bar` syntax.
- Empty modules, modules containing only methods/constants/other modules, and classes nested inside other classes are still allowed; only the `module Foo; class Bar; end; end` shape is rejected.
- Refactors the gem's own `lib/` files to use compact namespacing so it complies with the new rule, and centralizes the `RuboCop::Cop::Elegant` and `RuboCop::Elegant` namespace declarations to keep each cop file at one top-level definition.

## Test plan
- [x] `bundle exec rake` (160 tests, 27 files, 0 offenses)
- [x] New `NoClassInModuleTest` covers 11 allowed cases (compact namespacing, empty modules, nested empty modules, modules with only methods/constants, top-level classes, classes nested inside other classes) and 6 violation cases (single-module nesting, deep module nesting, multiple classes in one module, inheritance, mixed-with-empty-submodule, and the "outer-only" rule for class-in-class-in-module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)