### PR TITLE
#39: auto-correct support for PairedBrackets

### DIFF
--- a/lib/rubocop/cop/elegant/paired_brackets.rb
+++ b/lib/rubocop/cop/elegant/paired_brackets.rb
@@ -9,8 +9,17 @@
 # closing). Brackets stranded in the middle of a multi-line expression
 # are forbidden because they hide the structure of the code.
 #
+# Auto-correct relocates the offending bracket onto its own line: an
+# opener that is not at end-of-line gets a newline and the opener-line
+# indent plus two spaces inserted right after it; a closer that is not
+# at start-of-line gets a newline and the opener-line indent inserted
+# right before it. Surrounding indentation may still need a follow-up
+# layout pass, but the brackets themselves end up paired.
+#
 # See https://www.yegor256.com/2014/10/23/paired-brackets-notation.html
 class RuboCop::Cop::Elegant::PairedBrackets < RuboCop::Cop::Base
+  extend RuboCop::Cop::AutoCorrector
+
   MSG = 'Bracket %<text>s must be paired on the same line, or start/end its line'
   public_constant :MSG
 
@@ -43,8 +52,9 @@ class RuboCop::Cop::Elegant::PairedBrackets < RuboCop::Cop::Base
   def check(duo)
     opener, closer = duo
     return if opener.line == closer.line
-    register(opener) unless ends?(opener)
-    register(closer) unless starts?(closer)
+    indent = leading(opener)
+    register(opener) { |corrector| corrector.insert_after(opener.pos, "\n#{indent}  ") } unless ends?(opener)
+    register(closer) { |corrector| corrector.insert_before(closer.pos, "\n#{indent}") } unless starts?(closer)
   end
 
   def starts?(tok)
@@ -56,7 +66,11 @@ class RuboCop::Cop::Elegant::PairedBrackets < RuboCop::Cop::Base
     after.empty? || after.start_with?('#')
   end
 
-  def register(tok)
-    add_offense(tok.pos, message: format(MSG, text: tok.text))
+  def leading(tok)
+    processed_source.lines[tok.line - 1][/\A[ \t]*/]
+  end
+
+  def register(tok, &block)
+    add_offense(tok.pos, message: format(MSG, text: tok.text), &block)
   end
 end

--- a/test/elegant/test_paired_brackets.rb
+++ b/test/elegant/test_paired_brackets.rb
@@ -67,7 +67,8 @@ class PairedBracketsTest < Minitest::Test
   AUTOCORRECTIONS.each do |name, (source, expected)|
     define_method("test_auto_corrects_#{name}") do
       fixed = autocorrect(source)
-      assert_equal(expected, fixed, "Expected auto-correct on #{name.tr('_', ' ')} to produce #{expected.inspect}, got #{fixed.inspect}")
+      msg = "Auto-correct on #{name.tr('_', ' ')} did not produce #{expected.inspect}, got #{fixed.inspect}"
+      assert_equal(expected, fixed, msg)
     end
   end
 
@@ -83,8 +84,9 @@ class PairedBracketsTest < Minitest::Test
 
   def autocorrect(source)
     processed = RuboCop::ProcessedSource.new(source, Float(RUBY_VERSION[/[0-9]+.[0-9]+/]))
-    cop = RuboCop::Cop::Elegant::PairedBrackets.new(RuboCop::Config.new)
-    found = RuboCop::Cop::Commissioner.new([cop], [], raise_error: true).investigate(processed).offenses
+    found = RuboCop::Cop::Commissioner.new(
+      [RuboCop::Cop::Elegant::PairedBrackets.new(RuboCop::Config.new)], [], raise_error: true
+    ).investigate(processed).offenses
     corrector = RuboCop::Cop::Corrector.new(processed)
     found.each { |o| corrector.merge!(o.corrector) unless o.corrector.nil? }
     corrector.process

--- a/test/elegant/test_paired_brackets.rb
+++ b/test/elegant/test_paired_brackets.rb
@@ -39,6 +39,17 @@ class PairedBracketsTest < Minitest::Test
   }.freeze
   public_constant :VIOLATIONS
 
+  AUTOCORRECTIONS = {
+    'closer_not_at_start_of_line' => ["foo(\n  1)", "foo(\n  1\n)"],
+    'opener_not_at_end_of_line' => ["foo(1,\n  2\n)", "foo(\n  1,\n  2\n)"],
+    'split_square_brackets_in_middle' => ["[1,\n 2]", "[\n  1,\n 2\n]"],
+    'closer_in_middle_when_chained' => ["foo(\n  1).bar", "foo(\n  1\n).bar"],
+    'opener_in_middle_of_line' => ["foo(bar(\n  1\n))", "foo(\n  bar(\n  1\n)\n)"],
+    'opener_with_indent' => ["  foo(1,\n    2\n  )", "  foo(\n    1,\n    2\n  )"],
+    'closer_with_indent' => ["  foo(\n    1)", "  foo(\n    1\n  )"]
+  }.freeze
+  public_constant :AUTOCORRECTIONS
+
   ALLOWED.each do |name, source|
     define_method("test_allows_#{name}") do
       total = offenses(source).size
@@ -53,6 +64,13 @@ class PairedBracketsTest < Minitest::Test
     end
   end
 
+  AUTOCORRECTIONS.each do |name, (source, expected)|
+    define_method("test_auto_corrects_#{name}") do
+      fixed = autocorrect(source)
+      assert_equal(expected, fixed, "Expected auto-correct on #{name.tr('_', ' ')} to produce #{expected.inspect}, got #{fixed.inspect}")
+    end
+  end
+
   private
 
   def offenses(source)
@@ -61,5 +79,14 @@ class PairedBracketsTest < Minitest::Test
     ).investigate(
       RuboCop::ProcessedSource.new(source, Float(RUBY_VERSION[/[0-9]+.[0-9]+/]))
     ).offenses
+  end
+
+  def autocorrect(source)
+    processed = RuboCop::ProcessedSource.new(source, Float(RUBY_VERSION[/[0-9]+.[0-9]+/]))
+    cop = RuboCop::Cop::Elegant::PairedBrackets.new(RuboCop::Config.new)
+    found = RuboCop::Cop::Commissioner.new([cop], [], raise_error: true).investigate(processed).offenses
+    corrector = RuboCop::Cop::Corrector.new(processed)
+    found.each { |o| corrector.merge!(o.corrector) unless o.corrector.nil? }
+    corrector.process
   end
 end


### PR DESCRIPTION
Closes #39. The `Elegant/PairedBrackets` cop now extends `RuboCop::Cop::AutoCorrector` and attaches a corrector block to every offense, so `rubocop -a` rewrites a stranded bracket onto its own line instead of just flagging it. An opener that is not at end-of-line gets a newline and the opener-line indent plus two spaces inserted right after it, and a closer that is not at start-of-line gets a newline and the opener-line indent inserted right before it. Surrounding indentation may still need a follow-up layout pass, but the brackets themselves end up paired, which unblocks large-scale rewrites such as inlining variables flagged by `Elegant/NoRedundantVariable`.