### PR TITLE
#40: add auto-correct to NoRedundantVariable

### DIFF
--- a/lib/rubocop/cop/elegant/no_redundant_variable.rb
+++ b/lib/rubocop/cop/elegant/no_redundant_variable.rb
@@ -79,22 +79,45 @@ class RuboCop::Cop::Elegant::NoRedundantVariable < RuboCop::Cop::Base
   end
 
   def register(assign, read, name)
+    return add_offense(assign, message: format(MSG, name: name)) unless solo?(assign)
     add_offense(assign, message: format(MSG, name: name)) do |corrector|
-      corrector.replace(read.source_range, inlined(assign.children.last))
+      corrector.replace(read.source_range, inlined(assign.children.last, read))
       corrector.remove(range_by_whole_lines(assign.source_range, include_final_newline: true))
     end
   end
 
-  def inlined(rhs)
+  def solo?(assign)
+    range = assign.source_range
+    return false unless range.first_line == range.last_line
+    range.source_buffer.source_line(range.first_line).strip == range.source.strip
+  end
+
+  def inlined(rhs, read)
+    return "(#{braced(rhs)})" if wrap?(rhs, read)
+    braced(rhs)
+  end
+
+  def braced(rhs)
     return "{ #{rhs.source} }" if rhs.hash_type? && rhs.loc.begin.nil?
-    return rhs.source if primary?(rhs)
-    "(#{rhs.source})"
+    rhs.source
+  end
+
+  def wrap?(rhs, read)
+    return true unless primary?(rhs)
+    rhs.hash_type? && bare?(read)
   end
 
   def primary?(node)
     return true if PRIMARY_TYPES.include?(node.type)
     return !node.loc.begin.nil? || node.arguments.empty? if node.send_type? || node.csend_type?
     node.begin_type? && node.children.size == 1
+  end
+
+  def bare?(read)
+    parent = read.parent
+    return false if parent.nil?
+    return false unless parent.send_type? || parent.csend_type?
+    parent.loc.begin.nil? && parent.arguments.include?(read)
   end
 
   def walk(node, assigns, reads, tainted)

--- a/lib/rubocop/cop/elegant/no_redundant_variable.rb
+++ b/lib/rubocop/cop/elegant/no_redundant_variable.rb
@@ -19,7 +19,19 @@
 # whether or when the right-hand side is evaluated. A variable that
 # is reassigned, read more than once, or never read is left alone
 # too.
+#
+# Auto-correct inlines the redundant assignment: it replaces the
+# single +lvar+ read with the source of the assignment's right-hand
+# side, then removes the whole assignment line including its leading
+# indent and trailing newline. The right-hand side is wrapped in
+# parentheses unless it is already a primary expression (literal,
+# variable, parenthesized expression, or method call with parentheses
+# or no arguments), so that operator precedence at the read site is
+# preserved.
 class RuboCop::Cop::Elegant::NoRedundantVariable < RuboCop::Cop::Base
+  extend RuboCop::Cop::AutoCorrector
+  include RuboCop::Cop::RangeHelp
+
   MSG = 'Variable "%<name>s" is redundant and must be inlined: it is read only once'
   public_constant :MSG
 
@@ -34,6 +46,12 @@ class RuboCop::Cop::Elegant::NoRedundantVariable < RuboCop::Cop::Base
 
   ALWAYS_HOIST_TYPES = %i[rescue resbody ensure].freeze
   public_constant :ALWAYS_HOIST_TYPES
+
+  PRIMARY_TYPES = %i[
+    int float str sym dstr dsym xstr true false nil array hash regexp
+    lvar ivar cvar gvar const self nth_ref back_ref
+  ].freeze
+  public_constant :PRIMARY_TYPES
 
   def on_def(node)
     check(node.body)
@@ -56,8 +74,27 @@ class RuboCop::Cop::Elegant::NoRedundantVariable < RuboCop::Cop::Base
       next unless nodes.size == 1
       next unless reads[name].size == 1
       next if hoisted?(reads[name].first, nodes.first)
-      add_offense(nodes.first, message: format(MSG, name: name))
+      register(nodes.first, reads[name].first, name)
     end
+  end
+
+  def register(assign, read, name)
+    add_offense(assign, message: format(MSG, name: name)) do |corrector|
+      corrector.replace(read.source_range, inlined(assign.children.last))
+      corrector.remove(range_by_whole_lines(assign.source_range, include_final_newline: true))
+    end
+  end
+
+  def inlined(rhs)
+    return "{ #{rhs.source} }" if rhs.hash_type? && rhs.loc.begin.nil?
+    return rhs.source if primary?(rhs)
+    "(#{rhs.source})"
+  end
+
+  def primary?(node)
+    return true if PRIMARY_TYPES.include?(node.type)
+    return !node.loc.begin.nil? || node.arguments.empty? if node.send_type? || node.csend_type?
+    node.begin_type? && node.children.size == 1
   end
 
   def walk(node, assigns, reads, tainted)

--- a/test/elegant/test_no_redundant_variable.rb
+++ b/test/elegant/test_no_redundant_variable.rb
@@ -87,7 +87,11 @@ class NoRedundantVariableTest < Minitest::Test
     'multiple_redundant_inline_together' =>
       ["def foo\n  a = one\n  b = two\n  bar(a, b)\nend", "def foo\n  bar(one, two)\nend"],
     'class_method_inlines' =>
-      ["def self.foo\n  x = bar\n  baz(x)\nend", "def self.foo\n  baz(bar)\nend"]
+      ["def self.foo\n  x = bar\n  baz(x)\nend", "def self.foo\n  baz(bar)\nend"],
+    'shared_line_assignment_is_left_alone' =>
+      ["def foo\n  x = bar; baz(x)\nend", "def foo\n  x = bar; baz(x)\nend"],
+    'hash_into_bare_send_arg_is_wrapped' =>
+      ["def foo\n  x = { a: 1 }\n  baz x\nend", "def foo\n  baz ({ a: 1 })\nend"]
   }.freeze
   public_constant :AUTOCORRECTIONS
 

--- a/test/elegant/test_no_redundant_variable.rb
+++ b/test/elegant/test_no_redundant_variable.rb
@@ -65,6 +65,29 @@ class NoRedundantVariableTest < Minitest::Test
   }.freeze
   public_constant :VIOLATIONS
 
+  AUTOCORRECTIONS = {
+    'send_call_inlines_unwrapped' =>
+      ["def foo\n  x = bar\n  baz(x)\nend", "def foo\n  baz(bar)\nend"],
+    'integer_literal_inlines_unwrapped' =>
+      ["def foo\n  x = 42\n  baz(x)\nend", "def foo\n  baz(42)\nend"],
+    'returned_directly_inlines' =>
+      ["def foo\n  x = compute\n  x\nend", "def foo\n  compute\nend"],
+    'binary_operator_wrapped_in_parens' =>
+      ["def foo\n  x = a + b\n  baz(x)\nend", "def foo\n  baz((a + b))\nend"],
+    'ternary_wrapped_in_parens' =>
+      ["def foo\n  x = cond ? a : b\n  baz(x)\nend", "def foo\n  baz((cond ? a : b))\nend"],
+    'braceless_hash_inlines_with_braces' =>
+      ["def foo\n  x = a: 1, b: 2\n  baz(x)\nend", "def foo\n  baz({ a: 1, b: 2 })\nend"],
+    'inside_block_inlines' =>
+      ["def foo\n  arr.each do |e|\n    y = e.bar\n    baz(y)\n  end\nend",
+       "def foo\n  arr.each do |e|\n    baz(e.bar)\n  end\nend"],
+    'multiple_redundant_inline_together' =>
+      ["def foo\n  a = one\n  b = two\n  bar(a, b)\nend", "def foo\n  bar(one, two)\nend"],
+    'class_method_inlines' =>
+      ["def self.foo\n  x = bar\n  baz(x)\nend", "def self.foo\n  baz(bar)\nend"]
+  }.freeze
+  public_constant :AUTOCORRECTIONS
+
   ALLOWED.each do |name, source|
     define_method("test_allows_#{name}") do
       total = offenses(source).size
@@ -76,6 +99,14 @@ class NoRedundantVariableTest < Minitest::Test
     define_method("test_registers_offense_for_#{name}") do
       total = offenses(source).size
       assert_equal(count, total, "Expected #{count} offense(s) for #{name.tr('_', ' ')}, got #{total}")
+    end
+  end
+
+  AUTOCORRECTIONS.each do |name, (source, expected)|
+    define_method("test_auto_corrects_#{name}") do
+      fixed = autocorrect(source)
+      msg = "Auto-correct on #{name.tr('_', ' ')} did not produce #{expected.inspect}, got #{fixed.inspect}"
+      assert_equal(expected, fixed, msg)
     end
   end
 
@@ -97,5 +128,15 @@ class NoRedundantVariableTest < Minitest::Test
     ).investigate(
       RuboCop::ProcessedSource.new(source, Float(RUBY_VERSION[/[0-9]+.[0-9]+/]))
     ).offenses
+  end
+
+  def autocorrect(source)
+    processed = RuboCop::ProcessedSource.new(source, Float(RUBY_VERSION[/[0-9]+.[0-9]+/]))
+    found = RuboCop::Cop::Commissioner.new(
+      [RuboCop::Cop::Elegant::NoRedundantVariable.new(RuboCop::Config.new)], [], raise_error: true
+    ).investigate(processed).offenses
+    corrector = RuboCop::Cop::Corrector.new(processed)
+    found.each { |o| corrector.merge!(o.corrector) unless o.corrector.nil? }
+    corrector.process
   end
 end

--- a/test/elegant/test_no_redundant_variable.rb
+++ b/test/elegant/test_no_redundant_variable.rb
@@ -76,11 +76,14 @@ class NoRedundantVariableTest < Minitest::Test
       ["def foo\n  x = a + b\n  baz(x)\nend", "def foo\n  baz((a + b))\nend"],
     'ternary_wrapped_in_parens' =>
       ["def foo\n  x = cond ? a : b\n  baz(x)\nend", "def foo\n  baz((cond ? a : b))\nend"],
-    'braceless_hash_inlines_with_braces' =>
-      ["def foo\n  x = a: 1, b: 2\n  baz(x)\nend", "def foo\n  baz({ a: 1, b: 2 })\nend"],
-    'inside_block_inlines' =>
-      ["def foo\n  arr.each do |e|\n    y = e.bar\n    baz(y)\n  end\nend",
-       "def foo\n  arr.each do |e|\n    baz(e.bar)\n  end\nend"],
+    'hash_literal_with_braces_inlines_unwrapped' =>
+      ["def foo\n  x = { a: 1 }\n  baz(x)\nend", "def foo\n  baz({ a: 1 })\nend"],
+    'method_with_receiver_no_args_inlines_unwrapped' =>
+      ["def foo\n  x = a.b\n  baz(x)\nend", "def foo\n  baz(a.b)\nend"],
+    'inside_block_inlines' => [
+      "def foo\n  arr.each do |e|\n    y = e.bar\n    baz(y)\n  end\nend",
+      "def foo\n  arr.each do |e|\n    baz(e.bar)\n  end\nend"
+    ],
     'multiple_redundant_inline_together' =>
       ["def foo\n  a = one\n  b = two\n  bar(a, b)\nend", "def foo\n  bar(one, two)\nend"],
     'class_method_inlines' =>


### PR DESCRIPTION
Closes #40. The Elegant/NoRedundantVariable cop now extends RuboCop::Cop::AutoCorrector and emits a corrector that inlines the redundant local: it replaces the single lvar read with the source of the assignment's right-hand side and removes the assignment line including its leading indent and trailing newline. The right-hand side is wrapped in parentheses unless it is already a primary expression (literal, variable, parenthesized expression, or method call with parens or no arguments), so operator precedence at the read site is preserved.