### PR TITLE
#60: Flag explicit nil returns in blocks, lambdas, and procs

### DIFF
--- a/lib/rubocop/cop/elegant/no_nil_return.rb
+++ b/lib/rubocop/cop/elegant/no_nil_return.rb
@@ -3,22 +3,34 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-# Forbids a method from returning the literal +nil+ explicitly. The
-# cop flags two patterns: a +return nil+ statement anywhere inside
-# the method body, and a method whose tail expression is the literal
-# +nil+ (whether it stands alone or appears as the last statement of
-# a multi-statement body). Methods that omit +return+, use a bare
+# Forbids returning the literal +nil+ explicitly. The cop flags two
+# patterns: a +return nil+ statement anywhere inside the body, and a
+# body whose tail expression is the literal +nil+ (whether it stands
+# alone or appears as the last statement of a multi-statement body).
+# Both patterns are checked inside method definitions and inside
+# blocks, lambdas, and procs. Bodies that omit +return+, use a bare
 # +return+ keyword, or merely happen to evaluate to +nil+ through
 # control flow are not flagged.
 class RuboCop::Cop::Elegant::NoNilReturn < RuboCop::Cop::Base
   MSG = 'Method must not return nil explicitly'
   public_constant :MSG
 
+  SCOPES = %i[def defs block numblock].freeze
+  private_constant :SCOPES
+
   def on_def(node)
     check(node)
   end
 
   def on_defs(node)
+    check(node)
+  end
+
+  def on_block(node)
+    check(node)
+  end
+
+  def on_numblock(node)
     check(node)
   end
 
@@ -32,7 +44,7 @@ class RuboCop::Cop::Elegant::NoNilReturn < RuboCop::Cop::Base
 
   def explicit(node)
     node.each_descendant(:return) do |ret|
-      next unless ret.each_ancestor(:def, :defs).first.equal?(node)
+      next unless ret.each_ancestor(*SCOPES).first.equal?(node)
       add_offense(ret) if void?(ret)
     end
   end

--- a/test/elegant/test_no_nil_return.rb
+++ b/test/elegant/test_no_nil_return.rb
@@ -26,7 +26,13 @@ class NoNilReturnTest < Minitest::Test
     'modifier_if' => 'def foo; bar if x; end',
     'case_without_else' => 'def foo; case x; when 1; 2; end; end',
     'if_branch_contains_nil' => 'def foo; if x; nil; else; 2; end; end',
-    'case_else_is_nil' => 'def foo; case x; when 1; 2; else; nil; end; end'
+    'case_else_is_nil' => 'def foo; case x; when 1; 2; else; nil; end; end',
+    'block_non_nil_tail' => 'foo { 42 }',
+    'lambda_non_nil_tail' => '-> { 42 }',
+    'proc_non_nil_tail' => 'proc { 42 }',
+    'block_bare_return' => 'foo { return if x }',
+    'numblock_non_nil_tail' => 'foo { _1 }',
+    'empty_block_body' => 'foo {}'
   }.freeze
   public_constant :ALLOWED
 
@@ -40,7 +46,13 @@ class NoNilReturnTest < Minitest::Test
       ["def foo\n  return nil if x\n  return nil if y\n  bar\nend", 2],
     'return_nil_alongside_nil_tail' =>
       ["def foo\n  return nil if x\n  nil\nend", 2],
-    'kwbegin_nil_tail' => ["def foo\n  begin\n    bar\n    nil\n  end\nend", 1]
+    'kwbegin_nil_tail' => ["def foo\n  begin\n    bar\n    nil\n  end\nend", 1],
+    'block_nil_tail' => ['foo { nil }', 1],
+    'lambda_nil_tail' => ['-> { nil }', 1],
+    'proc_return_nil' => ['proc { return nil }', 1],
+    'block_return_nil_if' => ['foo { return nil if x }', 1],
+    'block_multi_statement_nil_tail' => ["foo do\n  bar\n  nil\nend", 1],
+    'numblock_nil_tail' => ["foo do\n  _1\n  nil\nend", 1]
   }.freeze
   public_constant :VIOLATIONS
 
@@ -61,6 +73,11 @@ class NoNilReturnTest < Minitest::Test
   def test_attributes_offense_only_to_inner_nested_def
     total = offenses("def foo\n  def bar\n    return nil\n  end\n  42\nend").size
     assert_equal(1, total, "Inner def with return nil should produce exactly 1 offense, got #{total}")
+  end
+
+  def test_attributes_offense_only_to_block
+    total = offenses("def foo\n  bar { return nil }\n  42\nend").size
+    assert_equal(1, total, "return nil inside a block should produce exactly 1 offense, got #{total}")
   end
 
   private


### PR DESCRIPTION
Fixes #60.

## Problem

`Elegant/NoNilReturn` only registered `on_def` and `on_defs`, so it inspected method bodies alone. Explicit `nil` returns inside blocks, lambdas, and procs slipped through unflagged — `foo { nil }`, `-> { nil }`, and `proc { return nil }` all passed.

## Change

- Added `on_block` and `on_numblock` handlers that run the existing `check` logic (reusing `explicit` and `tail`) against the block body. A `nil` tail or an explicit `return nil` inside any block, lambda, or proc is now reported the same way it is inside a method.
- Reworked the attribution in `explicit` to walk to the nearest enclosing scope among `def`, `defs`, `block`, and `numblock` (via a new `SCOPES` constant) instead of just `def`/`defs`. This ensures a `return nil` inside a block nested in a method is attributed to the block and counted exactly once, avoiding double-counting.
- Updated the class documentation to reflect that both patterns are now checked in blocks as well as methods.

## Tests

- Added `ALLOWED` cases: non-nil block/lambda/proc tails, bare `return` in a block, non-nil numblock tail, and an empty block body.
- Added `VIOLATIONS` cases: `nil` tail in a block/lambda, `return nil` in a proc, `return nil if x` in a block, multi-statement `nil` tail, and a numblock `nil` tail.
- Added `test_attributes_offense_only_to_block` to guard against double-counting a `return nil` in a block nested inside a method.

Full suite: 280 tests, 0 failures. RuboCop clean across the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTC4mjgEvGn6hwd2AYiG4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTC4mjgEvGn6hwd2AYiG4F)_