### PR TITLE
Add Layout/ArrayAlignment with_fixed_indentation to resolve conflict with Elegant/MonotonicIndents

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -103,6 +103,8 @@ Layout/EndOfLine:
   EnforcedStyle: lf
 Layout/ParameterAlignment:
   Enabled: false
+Layout/ArrayAlignment:
+  EnforcedStyle: with_fixed_indentation
 Layout/LineLength:
   Max: 120
 Style/MultilineBlockChain:


### PR DESCRIPTION
Fixes #63.

## Problem

`config/default.yml` did not configure `Layout/ArrayAlignment`, so RuboCop fell back to its default `EnforcedStyle: with_first_element`. That style aligns continuation elements under the first element of the array, which requires an indentation jump larger than two spaces — exactly what `Elegant/MonotonicIndents` forbids. As a result, any multi-line array literal was unfixable: the two cops could never both be satisfied.

## Fix

Added `Layout/ArrayAlignment` with `EnforcedStyle: with_fixed_indentation` to `config/default.yml`, so the alignment cop enforces the same two-space step that `MonotonicIndents` requires:

```ruby
NAMES = [
  'alice',
  'bob'
]
```

## Verification

- Confirmed the desired two-space layout passes both `Layout/ArrayAlignment` and `Elegant/MonotonicIndents` with no offenses.
- Confirmed the previously-conflicting `with_first_element` layout is now flagged by `Layout/ArrayAlignment` and autocorrects to the fixed two-space step.
- Existing test suite passes (5 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCczxuos4gYV92XBewWaHE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCczxuos4gYV92XBewWaHE)_