### PR TITLE
#57: Skip operator methods in Elegant/GoodMethodName

### DIFF
--- a/lib/rubocop/cop/elegant/good_method_name.rb
+++ b/lib/rubocop/cop/elegant/good_method_name.rb
@@ -18,9 +18,14 @@ class RuboCop::Cop::Elegant::GoodMethodName < RuboCop::Cop::Base
   private
 
   def check(node, name)
+    return unless identifier?(name)
     return if allowed?(name)
     return if match?(name)
     add_offense(node, message: format(MSG, name: name))
+  end
+
+  def identifier?(name)
+    /\A[a-zA-Z_]/.match?(name)
   end
 
   def match?(name)

--- a/test/elegant/test_good_method_name.rb
+++ b/test/elegant/test_good_method_name.rb
@@ -15,7 +15,19 @@ class GoodMethodNameTest < Minitest::Test
     ['def test_something_works; end', 'test_ prefix'],
     ['def fake_response; end', 'fake_ prefix'],
     ['def the_answer; end', 'the_ prefix'],
-    ['def self.foo; end', 'class method']
+    ['def self.foo; end', 'class method'],
+    ['def ==(other); end', 'equality operator'],
+    ['def <=>(other); end', 'spaceship operator'],
+    ['def +(other); end', 'plus operator'],
+    ['def -(other); end', 'minus operator'],
+    ['def *(other); end', 'multiply operator'],
+    ['def /(other); end', 'divide operator'],
+    ['def <(other); end', 'less than operator'],
+    ['def >(other); end', 'greater than operator'],
+    ['def <=(other); end', 'less than or equal operator'],
+    ['def [](index); end', 'index operator'],
+    ['def []=(index, value); end', 'index assignment operator'],
+    ['def self.==(other); end', 'class equality operator']
   ].each do |source, description|
     define_method("test_allows_#{description.gsub(/\s+/, '_')}") do
       assert_equal(0, offenses(source).size, "#{description} should be allowed")


### PR DESCRIPTION
Fixes #57.

## Problem

`Elegant/GoodMethodName` checked every method definition against the configured `Pattern`, including operator methods. For `def ==`, `def <=>`, `def +`, `def []`, etc., `node.method_name.to_s` yields `"=="`, `"<=>"`, `"+"`, `"[]"` — none of which match the pattern, so each was flagged as an offense.

Since operator methods cannot be renamed, the cop was effectively unsatisfiable for any value object that overloads operators (e.g. a `Comparable` class defining `<=>`, or arithmetic types defining `+`/`-`/`*`), short of listing every operator in `AllowedNames`.

## Fix

`check` now returns early for method names that are not plain identifiers — i.e. names that do not begin with a letter or underscore. Operator methods are skipped entirely, while regular identifier names continue to be validated against the pattern and `AllowedNames` as before.

## Tests

Added cases covering `==`, `<=>`, `+`, `-`, `*`, `/`, `<`, `>`, `<=`, `[]`, `[]=`, and a class-level operator (`self.==`), all asserting zero offenses. Full suite (292 tests) and RuboCop pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHvYr12sQria4XdtPmLAi3

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHvYr12sQria4XdtPmLAi3)_