### PR TITLE
Elegant/NoRedundantVariable: only inline across side-effect-free code

### DIFF
--- a/lib/rubocop/cop/elegant/no_redundant_variable.rb
+++ b/lib/rubocop/cop/elegant/no_redundant_variable.rb
@@ -20,14 +20,31 @@
 # is reassigned, read more than once, or never read is left alone
 # too.
 #
+# Inlining moves the right-hand side down to the read, so whatever
+# ran in between would run before it instead. The variable is
+# therefore left alone unless that gap is side-effect free. The gap
+# spans the statements between the assignment and the read, and also
+# the operands that precede the read inside its own statement.
+# Side-effect free means literals, reads of local variables, +self+,
+# arrays, hashes, pairs and parenthesized groups of those. Everything
+# else is assumed to be observable: method calls, +yield+, blocks,
+# and reads of instance, class and global variables, constants and
+# back-references, which the right-hand side may itself write.
+# Another assignment that this cop inlines too is stepped over when
+# its own read comes later and its own gap is clean, since both
+# right-hand sides then keep their relative order.
+#
 # Auto-correct inlines the redundant assignment: it replaces the
 # single +lvar+ read with the source of the assignment's right-hand
 # side, then removes the whole assignment line including its leading
-# indent and trailing newline. The right-hand side is wrapped in
-# parentheses unless it is already a primary expression (literal,
-# variable, parenthesized expression, or method call with parentheses
-# or no arguments), so that operator precedence at the read site is
-# preserved.
+# indent and trailing newline. An assignment that shares its line
+# with other code, or whose own source contains the read of another
+# redundant variable, is reported but not corrected, since removing
+# its line would clobber the other rewrite; a later pass picks it up.
+# The right-hand side is wrapped in parentheses unless it is already
+# a primary expression (literal, variable, parenthesized expression,
+# or method call with parentheses or no arguments), so that operator
+# precedence at the read site is preserved.
 class RuboCop::Cop::Elegant::NoRedundantVariable < RuboCop::Cop::Base
   extend RuboCop::Cop::AutoCorrector
   include RuboCop::Cop::RangeHelp
@@ -53,6 +70,12 @@ class RuboCop::Cop::Elegant::NoRedundantVariable < RuboCop::Cop::Base
   ].freeze
   public_constant :PRIMARY_TYPES
 
+  PURE_TYPES = %i[
+    int float rational complex str sym true false nil array hash regexp regopt
+    irange erange lvar self pair begin
+  ].freeze
+  public_constant :PURE_TYPES
+
   def on_def(node)
     check(node.body)
   end
@@ -69,17 +92,40 @@ class RuboCop::Cop::Elegant::NoRedundantVariable < RuboCop::Cop::Base
     reads = Hash.new { |h, k| h[k] = [] }
     tainted = []
     walk(body, assigns, reads, tainted)
+    inline(singles(assigns, reads, tainted))
+  end
+
+  def singles(assigns, reads, tainted)
+    found = {}
     assigns.each do |name, nodes|
       next if tainted.include?(name)
       next unless nodes.size == 1
       next unless reads[name].size == 1
       next if hoisted?(reads[name].first, nodes.first)
-      register(nodes.first, reads[name].first, name)
+      found[nodes.first] = reads[name].first
+    end
+    found
+  end
+
+  def inline(singles)
+    movable = singles.select { |assign, _| solo?(assign) && !swallows?(assign, singles) }
+    crossings = {}
+    singles.each do |assign, read|
+      next if crossed?(read, assign, movable, crossings)
+      register(assign, read, movable.key?(assign))
     end
   end
 
-  def register(assign, read, name)
-    return add_offense(assign, message: format(MSG, name: name)) unless solo?(assign)
+  def swallows?(assign, singles)
+    range = assign.source_range
+    singles.any? do |_, read|
+      read.source_range.begin_pos > range.begin_pos && read.source_range.end_pos <= range.end_pos
+    end
+  end
+
+  def register(assign, read, correctable)
+    name = assign.children.first
+    return add_offense(assign, message: format(MSG, name: name)) unless correctable
     add_offense(assign, message: format(MSG, name: name)) do |corrector|
       corrector.replace(read.source_range, inlined(assign.children.last, read))
       corrector.remove(range_by_whole_lines(assign.source_range, include_final_newline: true))
@@ -164,5 +210,46 @@ class RuboCop::Cop::Elegant::NoRedundantVariable < RuboCop::Cop::Base
       parent = parent.parent
     end
     parent.nil?
+  end
+
+  def crossed?(read, assign, movable, crossings)
+    return crossings[assign] if crossings.key?(assign)
+    crossings[assign] = scan?(read, assign, movable, crossings)
+  end
+
+  def scan?(read, assign, movable, crossings)
+    child = read
+    parent = read.parent
+    until parent.nil?
+      return true unless before(parent, child, assign).all? do |node|
+        deferred?(node, read, movable, crossings)
+      end
+      return false if parent.equal?(assign.parent)
+      child = parent
+      parent = parent.parent
+    end
+    false
+  end
+
+  def before(parent, child, assign)
+    kids = parent.children
+    stop = kids.index { |node| node.equal?(child) }
+    return [] if stop.nil?
+    return kids[0...stop] unless parent.equal?(assign.parent)
+    kids[(kids.index { |node| node.equal?(assign) } + 1)...stop]
+  end
+
+  def deferred?(node, read, movable, crossings)
+    return true if pure?(node)
+    twin = movable[node]
+    return false if twin.nil?
+    return false if twin.source_range.begin_pos < read.source_range.begin_pos
+    !crossed?(twin, node, movable, crossings)
+  end
+
+  def pure?(node)
+    return true unless node.is_a?(RuboCop::AST::Node)
+    return false unless PURE_TYPES.include?(node.type)
+    node.each_child_node.all? { |kid| pure?(kid) }
   end
 end

--- a/test/elegant/test_no_redundant_variable.rb
+++ b/test/elegant/test_no_redundant_variable.rb
@@ -5,6 +5,7 @@
 
 require_relative '../../lib/rubocop-elegant'
 require_relative '../test__helper'
+require 'timeout'
 
 class NoRedundantVariableTest < Minitest::Test
   ALLOWED = {
@@ -38,7 +39,25 @@ class NoRedundantVariableTest < Minitest::Test
     'read_inside_and_rhs' => "def foo\n  x = compute\n  cond && bar(x)\nend",
     'read_inside_or_rhs' => "def foo\n  x = compute\n  cond || bar(x)\nend",
     'read_inside_rescue_body' => "def foo\n  x = compute\n  bar\nrescue\n  baz(x)\nend",
-    'read_inside_ensure' => "def foo\n  x = compute\n  bar\nensure\n  baz(x)\nend"
+    'read_inside_ensure' => "def foo\n  x = compute\n  bar\nensure\n  baz(x)\nend",
+    'call_between_assignment_and_read' => "def foo\n  line = receive\n  reader.close\n  bar(line)\nend",
+    'mutation_between_assignment_and_read' => "def foo\n  touched = ledger.uniq\n  ledger.clear\n  touched\nend",
+    'timed_call_between_assignment_and_read' => "def foo\n  started = monotonic\n  bar\n  monotonic - started\nend",
+    'yield_read_after_other_work' => "def foo\n  returned = yield\n  log(out)\n  returned\nend",
+    'calls_before_read_in_same_array' => "def foo\n  returned = yield\n  [out.string, err.string, returned]\nend",
+    'call_before_read_in_same_argument_list' => "def foo\n  x = bar\n  baz(qux, x)\nend",
+    'local_assignment_that_changes_saved_value' =>
+      "def foo\n  state = :old\n  saved = state\n  state = :new\n  saved\nend",
+    'constant_lookup_between_assignment_and_read' =>
+      "def foo\n  saved = $state\n  Trigger::Value\n  saved\nend",
+    'instance_variable_operand_before_read' => "def foo\n  x = bump\n  bar(@n, x)\nend",
+    'global_variable_operand_before_read' => "def foo\n  x = bump\n  bar($n, x)\nend",
+    'class_variable_operand_before_read' => "def foo\n  x = bump\n  bar(@@n, x)\nend",
+    'constant_operand_before_read' => "def foo\n  x = bump\n  bar(CONST, x)\nend",
+    'back_reference_operand_before_read' => "def foo\n  x = (s =~ /a/)\n  bar($~, x)\nend",
+    'instance_variable_inside_array_before_read' => "def foo\n  x = bump\n  bar([@n], x)\nend",
+    'chained_assignments_read_in_separate_statements' =>
+      "def foo\n  a = one\n  b = two\n  bar(a)\n  baz(b)\nend"
   }.freeze
   public_constant :ALLOWED
 
@@ -61,7 +80,29 @@ class NoRedundantVariableTest < Minitest::Test
     'read_in_and_lhs_position' =>
       ["def foo\n  x = bar\n  baz(x) && qux\nend", 1],
     'read_in_case_subject_position' =>
-      ["def foo\n  x = bar\n  case x\n  when 1\n    one\n  end\nend", 1]
+      ["def foo\n  x = bar\n  case x\n  when 1\n    one\n  end\nend", 1],
+    'pure_statement_between_assignment_and_read' =>
+      ["def foo\n  x = bar\n  1\n  baz(x)\nend", 1],
+    'rational_literal_between_assignment_and_read' =>
+      ["def foo\n  x = bar\n  1r\n  baz(x)\nend", 1],
+    'complex_literal_between_assignment_and_read' =>
+      ["def foo\n  x = bar\n  1i\n  baz(x)\nend", 1],
+    'inclusive_range_between_assignment_and_read' =>
+      ["def foo\n  x = bar\n  1..2\n  baz(x)\nend", 1],
+    'exclusive_range_between_assignment_and_read' =>
+      ["def foo\n  x = bar\n  1...2\n  baz(x)\nend", 1],
+    'pure_operands_before_read' =>
+      ["def foo\n  x = bar\n  baz(1, [2], x)\nend", 1],
+    'self_operand_before_read' =>
+      ["def foo\n  x = bar\n  baz(self, x)\nend", 1],
+    'local_operand_before_read' =>
+      ["def foo(y)\n  x = bar\n  baz(y, x)\nend", 1],
+    'read_inside_another_redundant_assignment' =>
+      ["def foo\n  a = one\n  b = [a]\n  bar(b)\nend", 2],
+    'call_after_read_in_same_argument_list' =>
+      ["def foo\n  x = bar\n  baz(x, qux)\nend", 1],
+    'chained_assignments_read_out_of_order' =>
+      ["def foo\n  a = one\n  b = two\n  bar(b, a)\nend", 1]
   }.freeze
   public_constant :VIOLATIONS
 
@@ -90,6 +131,22 @@ class NoRedundantVariableTest < Minitest::Test
       ["def self.foo\n  x = bar\n  baz(x)\nend", "def self.foo\n  baz(bar)\nend"],
     'shared_line_assignment_is_left_alone' =>
       ["def foo\n  x = bar; baz(x)\nend", "def foo\n  x = bar; baz(x)\nend"],
+    'call_between_assignment_and_read_is_left_alone' => [
+      "def foo\n  line = receive\n  reader.close\n  bar(line)\nend",
+      "def foo\n  line = receive\n  reader.close\n  bar(line)\nend"
+    ],
+    'calls_before_read_in_array_are_left_alone' => [
+      "def foo\n  returned = yield\n  [out.string, returned]\nend",
+      "def foo\n  returned = yield\n  [out.string, returned]\nend"
+    ],
+    'read_inside_another_redundant_assignment_inlines_the_inner_one' => [
+      "def foo\n  a = one\n  b = [a]\n  bar(b)\nend",
+      "def foo\n  b = [one]\n  bar(b)\nend"
+    ],
+    'instance_variable_operand_before_read_is_left_alone' => [
+      "def foo\n  x = bump\n  bar(@n, x)\nend",
+      "def foo\n  x = bump\n  bar(@n, x)\nend"
+    ],
     'hash_into_bare_send_arg_is_wrapped' =>
       ["def foo\n  x = { a: 1 }\n  baz x\nend", "def foo\n  baz ({ a: 1 })\nend"]
   }.freeze
@@ -125,6 +182,14 @@ class NoRedundantVariableTest < Minitest::Test
   def test_inner_def_does_not_pollute_outer_scope
     total = offenses("def foo\n  x = 1\n  def bar\n    x = 2\n    baz(x)\n  end\n  qux(x)\n  zap(x)\nend").size
     assert_equal(1, total, "Expected only the inner def's redundant variable to be flagged, got #{total}")
+  end
+
+  def test_scales_to_a_long_chain_of_assignments
+    assignments = (1..20).map { |idx| "  a#{idx} = f#{idx}" }
+    arguments = (1..20).map { |idx| "a#{idx}" }.join(', ')
+    source = ['def foo', *assignments, "  sink(#{arguments})", 'end'].join("\n")
+    total = Timeout.timeout(2) { offenses(source).size }
+    assert_equal(20, total, "Expected all 20 assignments to be flagged, got #{total}")
   end
 
   private


### PR DESCRIPTION
Fixes #72.

The auto-correct of `Elegant/NoRedundantVariable` can change the behavior of a
method. It moves the right-hand side of an assignment across code that has side
effects. This changes the order of those side effects. This pull request adds a
check: the cop inlines a variable only across code that has no side effects.

## Problem

The cop finds each local variable with one assignment and one read. The
auto-correct then moves the right-hand side down to the read. The only check was
`hoisted?`. This check knows loops and conditional branches. It does not know
side effects.

Therefore the auto-correct moved the right-hand side across statements that have
side effects. These three examples show the input, then the exact output of
`rubocop -a`:

```ruby
def measure
  started = monotonic
  outcome = attempt.run(tests)
  result(classify(outcome), monotonic - started)
end

# becomes: the timer measures nothing
def measure
  result(classify(attempt.run(tests)), monotonic - monotonic)
end
```

```ruby
def collect(reader)
  line = receive(reader)
  reader.close
  bar(line)
end

# becomes: the read happens after the pipe closes
def collect(reader)
  reader.close
  bar(receive(reader))
end
```

```ruby
def drain(ledger)
  touched = ledger.uniq
  ledger.clear
  touched
end

# becomes: the snapshot happens after the clear
def drain(ledger)
  ledger.clear
  ledger.uniq
end
```

Call the code between the assignment and the read "the gap". The gap contains
more than those statements. The gap also contains the operands before the read
in the same statement. Therefore the cop must not inline `returned` in
`[out.string, err.string, returned]`.

## Fix

The cop now examines the gap for side effects. It starts at the read. It
examines each level up to the sequence that contains the assignment. At each
level, all the siblings before the read must have no side effects. At the level
of the assignment, the cop examines only the siblings after the assignment.

These nodes have no side effects:

- Literals, ranges, arrays, hashes and pairs
- Reads of local variables, and `self`
- Groups of these nodes in parentheses

All other nodes have side effects. This includes method calls, `yield` and
blocks. It also includes reads of instance variables, class variables, global
variables, constants and back-references. The right-hand side can write the data
that these nodes read.

This check has two results:

- The gap can contain a second assignment that the cop also inlines. The cop
  skips that assignment if two conditions are true. The read of that
  assignment must come after the first read. The gap of that assignment must
  have no side effects. The two right-hand sides then keep their order.
  Therefore `a = one; b = two; bar(a, b)` is still two offenses. But for
  `bar(b, a)` and for `bar(a); baz(b)`, the cop now reports only the assignment
  that is safe to move.
- The source of an assignment can contain the read of a second redundant
  variable. The cop reports this assignment, but it does not correct it. To
  remove the line of this assignment destroys the second correction. A later
  pass corrects it.

## Tests

The tests now include:

- The three examples above
- Each type of operand with side effects: instance variables, class variables,
  global variables, constants, back-references, and one operand in an array
- Each type of operand with no side effects: literals, rationals, complexes,
  ranges, `self`, local variables
- The second assignment in a source, as an offense count and as an
  auto-correction

There is also a test with 20 assignments and a timeout of 2 seconds. The
examination of the gap is recursive. Therefore it needs a cache.

All 323 tests and `rake` are successful.