### PR TITLE
Elegant/NoRedundantVariable: expand Ruby 3.1 shorthand pairs when inlining

### DIFF
--- a/lib/rubocop/cop/elegant/no_redundant_variable.rb
+++ b/lib/rubocop/cop/elegant/no_redundant_variable.rb
@@ -23,7 +23,10 @@
 # Auto-correct inlines the redundant assignment: it replaces the
 # single +lvar+ read with the source of the assignment's right-hand
 # side, then removes the whole assignment line including its leading
-# indent and trailing newline. The right-hand side is wrapped in
+# indent and trailing newline. When the read is the value of a Ruby
+# 3.1 shorthand pair, such as the +ids+ of +call(ids:)+, key and
+# value share one range, so the whole pair is rewritten into its
+# long form +ids: <rhs>+ instead. The right-hand side is wrapped in
 # parentheses unless it is already a primary expression (literal,
 # variable, parenthesized expression, or method call with parentheses
 # or no arguments), so that operator precedence at the read site is
@@ -81,9 +84,24 @@ class RuboCop::Cop::Elegant::NoRedundantVariable < RuboCop::Cop::Base
   def register(assign, read, name)
     return add_offense(assign, message: format(MSG, name: name)) unless solo?(assign)
     add_offense(assign, message: format(MSG, name: name)) do |corrector|
-      corrector.replace(read.source_range, inlined(assign.children.last, read))
+      corrector.replace(*rewrite(assign.children.last, read))
       corrector.remove(range_by_whole_lines(assign.source_range, include_final_newline: true))
     end
+  end
+
+  def rewrite(rhs, read)
+    pair = shorthand(read)
+    return [read.source_range, inlined(rhs, read)] if pair.nil?
+    [pair.source_range, "#{pair.children.first.source}: #{inlined(rhs, read)}"]
+  end
+
+  def shorthand(read)
+    parent = read.parent
+    return if parent.nil? || !parent.pair_type?
+    key, value = parent.children
+    return unless value.equal?(read)
+    return unless key.source_range == value.source_range
+    parent
   end
 
   def solo?(assign)

--- a/test/elegant/test_no_redundant_variable.rb
+++ b/test/elegant/test_no_redundant_variable.rb
@@ -91,7 +91,13 @@ class NoRedundantVariableTest < Minitest::Test
     'shared_line_assignment_is_left_alone' =>
       ["def foo\n  x = bar; baz(x)\nend", "def foo\n  x = bar; baz(x)\nend"],
     'hash_into_bare_send_arg_is_wrapped' =>
-      ["def foo\n  x = { a: 1 }\n  baz x\nend", "def foo\n  baz ({ a: 1 })\nend"]
+      ["def foo\n  x = { a: 1 }\n  baz x\nend", "def foo\n  baz ({ a: 1 })\nend"],
+    'shorthand_pair_expands_to_long_form' =>
+      ["def foo\n  ids = compute\n  bar(ids:)\nend", "def foo\n  bar(ids: compute)\nend"],
+    'shorthand_pair_in_hash_literal_expands' =>
+      ["def foo\n  ids = compute\n  bar({ ids: })\nend", "def foo\n  bar({ ids: compute })\nend"],
+    'long_form_pair_still_inlines_the_value_only' =>
+      ["def foo\n  ids = compute\n  bar(list: ids)\nend", "def foo\n  bar(list: compute)\nend"]
   }.freeze
   public_constant :AUTOCORRECTIONS
 


### PR DESCRIPTION
Fixes #74.

The auto-correct of `Elegant/NoRedundantVariable` breaks Ruby 3.1 shorthand hash syntax. This pull request rewrites the whole pair instead of the value.

## Problem

`register` replaces the range of the `lvar` read. In a shorthand pair the key and the value have the same range:

```ruby
ids = source.map(&:id)
deliver(ids:)
```

`rubocop -a` writes `deliver(source.map(&:id):)`. That does not parse.

## Fix

`rewrite` returns the range to replace and the text to put there. When the read is the value of a pair whose key has the same range, it returns the range of the whole pair and the long form:

```ruby
deliver(ids: source.map(&:id))
```

Every other case returns the range of the read, as before.

## Tests

Three auto-correction tests: a shorthand pair in an argument list, a shorthand pair in a hash literal, and a long-form pair, which proves the old path is untouched.

All 295 tests and `rake` are successful.
