### PR TITLE
Elegant/ClassInModule: a class nested in a class is not global

### DIFF
--- a/lib/rubocop/cop/elegant/class_in_module.rb
+++ b/lib/rubocop/cop/elegant/class_in_module.rb
@@ -4,10 +4,13 @@
 # SPDX-License-Identifier: MIT
 
 # Enforces that every class be defined inside a module. A class declared
-# at the top level, or nested only inside another class, pollutes the
-# global namespace and breaks modular design. The compact namespaced
-# form +class Foo::Bar+ is allowed because its name already resolves
-# into an enclosing namespace.
+# at the top level pollutes the global namespace and breaks modular
+# design. The compact namespaced form +class Foo::Bar+ is allowed
+# because its name already resolves into an enclosing namespace, and so
+# is a class nested inside another class, since the enclosing class
+# names it too: +class Foo::Bar; class Baz+ defines +Foo::Bar::Baz+.
+# A class declared with an explicit root scope, +class ::Baz+, is global
+# whatever encloses it lexically, so it is reported wherever it sits.
 class RuboCop::Cop::Elegant::ClassInModule < RuboCop::Cop::Base
   MSG = 'Class %<name>s must be defined inside a module, not globally'
   public_constant :MSG
@@ -21,12 +24,17 @@ class RuboCop::Cop::Elegant::ClassInModule < RuboCop::Cop::Base
   private
 
   def namespaced?(node)
-    scope = node.children[0].children[0]
+    scope = outer(node)
     !scope.nil? && scope.type != :cbase
   end
 
   def scoped?(node)
-    node.each_ancestor(:module).any?
+    return false unless outer(node).nil?
+    node.each_ancestor(:module, :class).any?
+  end
+
+  def outer(node)
+    node.children[0].children[0]
   end
 
   def label(node)

--- a/test/elegant/test_class_in_module.rb
+++ b/test/elegant/test_class_in_module.rb
@@ -15,16 +15,19 @@ class ClassInModuleTest < Minitest::Test
     'module_without_any_class' => "module Foo\nend",
     'top_level_method_only' => "def foo\nend",
     'nested_class_inside_class_inside_module' => "module Foo\n  class Bar\n    class Baz\n    end\n  end\nend",
-    'class_with_inheritance_inside_module' => "module Foo\n  class Bar < StandardError\n  end\nend"
+    'class_with_inheritance_inside_module' => "module Foo\n  class Bar < StandardError\n  end\nend",
+    'class_nested_in_compact_namespaced_class' => "class Foo::Bar\n  class Baz < StandardError\n  end\nend"
   }.freeze
   public_constant :ALLOWED
 
   VIOLATIONS = {
     'plain_top_level_class' => ["class Foo\nend", 1],
     'top_level_class_with_explicit_root' => ["class ::Foo\nend", 1],
-    'top_level_class_with_nested_class' => ["class Foo\n  class Bar\n  end\nend", 2],
+    'top_level_class_with_nested_class' => ["class Foo\n  class Bar\n  end\nend", 1],
     'two_top_level_classes' => ["class Foo\nend\nclass Bar\nend", 2],
-    'top_level_class_with_inheritance' => ["class Foo < StandardError\nend", 1]
+    'top_level_class_with_inheritance' => ["class Foo < StandardError\nend", 1],
+    'root_scoped_class_inside_a_class' => ["class Foo::Bar\n  class ::Baz\n  end\nend", 1],
+    'root_scoped_class_inside_a_module' => ["module Foo\n  class ::Baz\n  end\nend", 1]
   }.freeze
   public_constant :VIOLATIONS
 


### PR DESCRIPTION
Fixes #75.

`Elegant/ClassInModule` reports a class nested in a class as global. This pull request treats an enclosing class as a scope.

## Problem

`scoped?` looks for a module ancestor only:

```ruby
class Account::Invitation
  class ExpiredError < StandardError
  end
end
```

The cop reports `ExpiredError`, whose name is `Account::Invitation::ExpiredError`. `Elegant/NoClassInModule` forbids the module this message asks for, so the two cops leave no shape to write.

## Fix

`scoped?` now accepts a class ancestor as well as a module ancestor.

A class with an explicit root scope is the exception. `class ::Baz` is `Object::Baz` whatever encloses it, so only a class whose own name carries no scope can be exempted by its ancestors. That closes a case the cop missed before:

```ruby
module Foo
  class ::Baz
  end
end
```

The cop was silent here. It now reports `::Baz`. This makes the cop report code that used to pass, so it may turn a green build red.

## Tests

One expectation changed. `class Foo; class Bar; end; end` was two offenses and is now one. Only `Foo` is global, and `Bar` becomes namespaced once `Foo` is fixed.

Three new cases: a class inside a compact namespaced class, `::Baz` inside a class, and `::Baz` inside a module.

All 295 tests and `rake` are successful.
