### PR TITLE
Elegant/PairedBrackets: consume the whitespace the moved bracket left behind

### DIFF
--- a/lib/rubocop/cop/elegant/paired_brackets.rb
+++ b/lib/rubocop/cop/elegant/paired_brackets.rb
@@ -10,11 +10,14 @@
 # are forbidden because they hide the structure of the code.
 #
 # Auto-correct relocates the offending bracket onto its own line: an
-# opener that is not at end-of-line gets a newline and the opener-line
-# indent plus two spaces inserted right after it; a closer that is not
-# at start-of-line gets a newline and the opener-line indent inserted
-# right before it. Surrounding indentation may still need a follow-up
-# layout pass, but the brackets themselves end up paired.
+# opener that is not at end-of-line is followed by a newline and the
+# opener-line indent plus two spaces; a closer that is not at
+# start-of-line is preceded by a newline and the opener-line indent.
+# The whitespace already sitting next to the bracket is consumed by
+# the rewrite rather than left in place, so the moved code lands on
+# the intended column instead of drifting right by that much.
+# Surrounding indentation may still need a follow-up layout pass, but
+# the brackets themselves end up paired.
 #
 # See https://www.yegor256.com/2014/10/23/paired-brackets-notation.html
 class RuboCop::Cop::Elegant::PairedBrackets < RuboCop::Cop::Base
@@ -28,6 +31,9 @@ class RuboCop::Cop::Elegant::PairedBrackets < RuboCop::Cop::Base
 
   CLOSERS = %i[tRPAREN tRBRACK tRCURLY].freeze
   private_constant :CLOSERS
+
+  BLANKS = [' ', "\t"].freeze
+  private_constant :BLANKS
 
   def on_new_investigation
     super
@@ -53,8 +59,22 @@ class RuboCop::Cop::Elegant::PairedBrackets < RuboCop::Cop::Base
     opener, closer = duo
     return if opener.line == closer.line
     indent = leading(opener)
-    register(opener) { |corrector| corrector.insert_after(opener.pos, "\n#{indent}  ") } unless ends?(opener)
-    register(closer) { |corrector| corrector.insert_before(closer.pos, "\n#{indent}") } unless starts?(closer)
+    register(opener) { |corrector| corrector.replace(trailing(opener), "\n#{indent}  ") } unless ends?(opener)
+    register(closer) { |corrector| corrector.replace(preceding(closer), "\n#{indent}") } unless starts?(closer)
+  end
+
+  def trailing(tok)
+    text = processed_source.buffer.source
+    stop = tok.pos.end_pos
+    stop += 1 while BLANKS.include?(text[stop])
+    tok.pos.end.resize(stop - tok.pos.end_pos)
+  end
+
+  def preceding(tok)
+    text = processed_source.buffer.source
+    from = tok.pos.begin_pos
+    from -= 1 while from.positive? && BLANKS.include?(text[from - 1])
+    tok.pos.begin.adjust(begin_pos: from - tok.pos.begin_pos)
   end
 
   def starts?(tok)

--- a/test/elegant/test_paired_brackets.rb
+++ b/test/elegant/test_paired_brackets.rb
@@ -46,7 +46,11 @@ class PairedBracketsTest < Minitest::Test
     'closer_in_middle_when_chained' => ["foo(\n  1).bar", "foo(\n  1\n).bar"],
     'opener_in_middle_of_line' => ["foo(bar(\n  1\n))", "foo(\n  bar(\n  1\n)\n)"],
     'opener_with_indent' => ["  foo(1,\n    2\n  )", "  foo(\n    1,\n    2\n  )"],
-    'closer_with_indent' => ["  foo(\n    1)", "  foo(\n    1\n  )"]
+    'closer_with_indent' => ["  foo(\n    1)", "  foo(\n    1\n  )"],
+    'space_after_opener_is_consumed' => ["  { a: 1,\n    b: 2 }", "  {\n    a: 1,\n    b: 2\n  }"],
+    'tabs_around_brackets_are_consumed' => ["  foo(\t1,\n    2\t)", "  foo(\n    1,\n    2\n  )"],
+    'multibyte_text_does_not_shift_the_offsets' =>
+      ["# \u20ac\nfoo( 1,\n  2 )", "# \u20ac\nfoo(\n  1,\n  2\n)"]
   }.freeze
   public_constant :AUTOCORRECTIONS
 


### PR DESCRIPTION
Fixes #76.

The auto-correct of `Elegant/PairedBrackets` leaves the whitespace next to the bracket in place, so corrected lines drift right. This pull request consumes that whitespace.

## Problem

`check` inserts a newline and an indent beside the bracket. The space that was already there survives:

```ruby
    { alphabetical: alpha,
      echo: alpha }
```

`rubocop -a` puts the first element at column 7 instead of column 6:

```ruby
    {
       alphabetical: alpha,
      echo: alpha
    }
```

`Elegant/MonotonicIndents` then reports a step of three spaces.

## Fix

`trailing` walks forward from the end of an opener over spaces and tabs. `preceding` walks back from the start of a closer. `check` calls `corrector.replace` on those ranges instead of inserting beside the bracket. Output is unchanged where there is no whitespace to consume.

`begin_pos` and `end_pos` are character offsets into the decoded buffer, so `String#[]` is the matching accessor. A test with a multibyte comment ahead of the call covers this.

## Tests

Three new auto-correction tests: a space after `{`, tabs on both sides, and a multibyte comment ahead of the call. The seven existing auto-correction tests are unchanged.

All 295 tests and `rake` are successful.
