### PR TITLE
config: test file exclusions never matched Rails' foo_test.rb

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -36,6 +36,10 @@ Elegant/ClassInModule:
   Exclude:
     - '**/*Test.rb'
     - '**/test_*.rb'
+    - '**/*_test.rb'
+    - '**/*_spec.rb'
+    - 'test/**/*'
+    - 'spec/**/*'
 Elegant/NoClassInModule:
   Description: 'Forbids declaring a class inside a module declaration; use compact namespace syntax instead'
   Enabled: true
@@ -43,6 +47,10 @@ Elegant/NoClassInModule:
   Exclude:
     - '**/*Test.rb'
     - '**/test_*.rb'
+    - '**/*_test.rb'
+    - '**/*_spec.rb'
+    - 'test/**/*'
+    - 'spec/**/*'
 Elegant/OneClassPerFile:
   Description: 'Allows only one non-empty top-level class per file; empty forward declarations are treated as namespace scaffolding'
   Enabled: true
@@ -50,6 +58,10 @@ Elegant/OneClassPerFile:
   Exclude:
     - '**/*Test.rb'
     - '**/test_*.rb'
+    - '**/*_test.rb'
+    - '**/*_spec.rb'
+    - 'test/**/*'
+    - 'spec/**/*'
 Elegant/MonotonicIndents:
   Description: 'Requires the indentation step to be exactly two spaces when a line indents to the right of the previous one'
   Enabled: true
@@ -78,11 +90,19 @@ Metrics/ModuleLength:
   Exclude:
     - '**/*Test.rb'
     - '**/test_*.rb'
+    - '**/*_test.rb'
+    - '**/*_spec.rb'
+    - 'test/**/*'
+    - 'spec/**/*'
 Metrics/ClassLength:
   Max: 300
   Exclude:
     - '**/*Test.rb'
     - '**/test_*.rb'
+    - '**/*_test.rb'
+    - '**/*_spec.rb'
+    - 'test/**/*'
+    - 'spec/**/*'
 Metrics/MethodLength:
   Max: 100
 Metrics/BlockLength:


### PR DESCRIPTION
Fixes #77.

The test file exclusions match `FooTest.rb` and `test_foo.rb` only. This pull request adds the Rails and RSpec conventions.

## Problem

Five cops exempt test files: `Elegant/ClassInModule`, `Elegant/NoClassInModule`, `Elegant/OneClassPerFile`, `Metrics/ClassLength` and `Metrics/ModuleLength`. Their globs are `'**/*Test.rb'` and `'**/test_*.rb'`.

Rails writes `account_test.rb`. RSpec writes `account_spec.rb`. The exclusions never fire on either, so a test file with one class per case is reported.

## Fix

Each of the five cops gains four globs:

```yaml
- '**/*_test.rb'
- '**/*_spec.rb'
- 'test/**/*'
- 'spec/**/*'
```

The directory globs cover fixtures, factories and support files, which follow no filename convention.

## Tests

Configuration only. All 292 tests and `rake` are successful.
